### PR TITLE
feat: persist per-page session in localStorage with page-level reset

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 ﻿import { useState, useRef, useCallback, useEffect } from "react";
 import T from "./constants/tokens";
 import useMediaQuery from "./hooks/useMediaQuery";
+import { PageSessionProvider, clearPersistedPageState, getPersistedActivePage, setPersistedActivePage } from "./hooks/usePageState";
 import { Sidebar, Topbar, Footer } from "./components/layout";
 import { ModuleContent } from "./components/modules";
 
@@ -8,7 +9,8 @@ const MOBILE_QUERY = `(max-width:${T.mobileBreakpoint}px)`;
 
 export default function App() {
   const isMobile = useMediaQuery(MOBILE_QUERY);
-  const [active, setActive] = useState("home");
+  const [active, setActive] = useState(() => getPersistedActivePage() || "home");
+  const [pageResetVersion, setPageResetVersion] = useState({});
   const [sideOpen, setSideOpen] = useState(!isMobile);
   const scrollRef = useRef(null);
 
@@ -20,6 +22,15 @@ export default function App() {
     setActive(id);
     setTimeout(() => { if (scrollRef.current) scrollRef.current.scrollTop = 0; }, 0);
   }, []);
+
+  useEffect(() => {
+    setPersistedActivePage(active);
+  }, [active]);
+
+  const handleResetPage = useCallback(() => {
+    clearPersistedPageState(active);
+    setPageResetVersion((prev) => ({ ...prev, [active]: (prev[active] || 0) + 1 }));
+  }, [active]);
 
   return (
     <div style={{ display: "flex", height: "100%", minHeight: "100vh", background: T.bg, color: T.text, fontFamily: "'Segoe UI',system-ui,sans-serif", overflow: "hidden", position: "relative" }}>
@@ -46,12 +57,14 @@ export default function App() {
       <Sidebar active={active} onNavigate={go} sideOpen={sideOpen} setSideOpen={setSideOpen} isMobile={isMobile} />
 
       <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden", zIndex: 1 }}>
-        <Topbar active={active} isMobile={isMobile} onMenuToggle={() => setSideOpen((o) => !o)} />
+        <Topbar active={active} isMobile={isMobile} onMenuToggle={() => setSideOpen((o) => !o)} onResetPage={handleResetPage} />
 
         <div ref={scrollRef} style={{ flex: 1, overflowY: "auto", padding: isMobile ? "16px 12px" : "22px 24px" }}>
           <div style={{ maxWidth: 820, margin: "0 auto" }}>
             <div style={{ animation: "fadeIn .2s ease" }}>
-              <ModuleContent id={active} isMobile={isMobile} />
+              <PageSessionProvider pageId={active}>
+                <ModuleContent key={`${active}:${pageResetVersion[active] || 0}`} id={active} isMobile={isMobile} />
+              </PageSessionProvider>
             </div>
           </div>
         </div>

--- a/src/components/layout/Topbar.jsx
+++ b/src/components/layout/Topbar.jsx
@@ -1,7 +1,7 @@
 import T from "../../constants/tokens";
 import MODULES from "../../constants/modules";
 
-export default function Topbar({ active, isMobile, onMenuToggle }) {
+export default function Topbar({ active, isMobile, onMenuToggle, onResetPage }) {
   const mod = MODULES.find((m) => m.id === active);
   return (
     <div
@@ -53,6 +53,29 @@ export default function Topbar({ active, isMobile, onMenuToggle }) {
           </div>
         )}
       </div>
+      {active !== "home" && (
+        <button
+          onClick={onResetPage}
+          title="Reset this page's progress"
+          style={{
+            background: T.red + "12",
+            border: `1px solid ${T.red}30`,
+            borderRadius: 7,
+            color: T.red,
+            fontSize: 11,
+            fontWeight: 600,
+            padding: isMobile ? "5px 10px" : "6px 12px",
+            cursor: "pointer",
+            whiteSpace: "nowrap",
+            flexShrink: 0,
+            transition: "all .15s",
+          }}
+          onMouseEnter={(e) => { e.currentTarget.style.background = T.red + "22"; e.currentTarget.style.borderColor = T.red + "50"; }}
+          onMouseLeave={(e) => { e.currentTarget.style.background = T.red + "12"; e.currentTarget.style.borderColor = T.red + "30"; }}
+        >
+          ↺ Reset Page
+        </button>
+      )}
     </div>
   );
 }

--- a/src/components/modules/BranchModule.jsx
+++ b/src/components/modules/BranchModule.jsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { usePageState } from "../../hooks/usePageState";
 import T from "../../constants/tokens";
 import { Badge, InfoBox, SectionTitle, CommandCard } from "../shared";
 
@@ -15,12 +16,12 @@ function getBranchNameError(name, branches) {
 }
 
 function BranchSimulator({ isMobile }) {
-  const [branches, setBranches] = useState([
+  const [branches, setBranches] = usePageState("branches", [
     { name: "main", commits: ["c0a1", "d4b2", "e9f3"], color: T.green, current: false },
     { name: "develop", commits: ["c0a1", "d4b2", "a1b2"], color: T.blue, current: true },
   ]);
   const [newName, setNewName] = useState("");
-  const [log, setLog] = useState(["Switched to branch 'develop'"]);
+  const [log, setLog] = usePageState("log", ["Switched to branch 'develop'"]);
 
   const current = branches.find((b) => b.current) ?? branches[0];
   const branchNameError = getBranchNameError(newName, branches);
@@ -186,3 +187,6 @@ export default function BranchModule({ isMobile }) {
     </div>
   );
 }
+
+
+

--- a/src/components/modules/CodeownersModule.jsx
+++ b/src/components/modules/CodeownersModule.jsx
@@ -1,16 +1,17 @@
 import { useState } from "react";
+import { usePageState } from "../../hooks/usePageState";
 import T from "../../constants/tokens";
 import { InfoBox, SectionTitle } from "../shared";
 
 function CodeownersSim({ isMobile }) {
-  const [rules, setRules] = useState([
+  const [rules, setRules] = usePageState("rules", [
     { pattern: "*", owners: "@alice @bob", note: "Default: review everything" },
     { pattern: "src/payments/", owners: "@payment-team", note: "Payment code" },
     { pattern: "*.md", owners: "@docs-team", note: "Documentation" },
     { pattern: ".github/", owners: "@devops", note: "CI and config" },
     { pattern: "src/auth/", owners: "@security-team", note: "Auth changes" },
   ]);
-  const [testFile, setTestFile] = useState("src/payments/checkout.js");
+  const [testFile, setTestFile] = usePageState("testFile", "src/payments/checkout.js");
   const [newR, setNewR] = useState({ pattern: "", owners: "" });
 
   const getMatch = (file) => {
@@ -112,3 +113,6 @@ export default function CodeownersModule({ isMobile }) {
     </div>
   );
 }
+
+
+

--- a/src/components/modules/CodespacesModule.jsx
+++ b/src/components/modules/CodespacesModule.jsx
@@ -1,10 +1,10 @@
-import { useState } from "react";
+import { usePageState } from "../../hooks/usePageState";
 import T from "../../constants/tokens";
 import { InfoBox, SectionTitle, CommandCard } from "../shared";
 
 function CodespacesSim({ isMobile }) {
-  const [phase, setPhase] = useState("idle");
-  const [log, setLog] = useState([]);
+  const [phase, setPhase] = usePageState("phase", "idle");
+  const [log, setLog] = usePageState("log", []);
 
   const boot = () => {
     setPhase("booting");
@@ -146,3 +146,6 @@ export default function CodespacesModule({ isMobile }) {
     </div>
   );
 }
+
+
+

--- a/src/components/modules/DependabotModule.jsx
+++ b/src/components/modules/DependabotModule.jsx
@@ -1,9 +1,9 @@
-import { useState } from "react";
+import { usePageState } from "../../hooks/usePageState";
 import T from "../../constants/tokens";
 import { InfoBox, SectionTitle } from "../shared";
 
 function DependabotSim({ isMobile }) {
-  const [deps, setDeps] = useState([
+  const [deps, setDeps] = usePageState("deps", [
     { name: "react", cur: "18.2.0", lat: "19.1.0", type: "major", sev: "none", pr: false },
     { name: "axios", cur: "1.6.0", lat: "1.7.2", type: "minor", sev: "none", pr: false },
     { name: "lodash", cur: "4.17.15", lat: "4.17.21", type: "patch", sev: "high", pr: false },
@@ -87,3 +87,6 @@ export default function DependabotModule({ isMobile }) {
     </div>
   );
 }
+
+
+

--- a/src/components/modules/DotGithubModule.jsx
+++ b/src/components/modules/DotGithubModule.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { usePageState } from "../../hooks/usePageState";
 import T from "../../constants/tokens";
 import { InfoBox, SectionTitle } from "../shared";
 
@@ -13,7 +13,7 @@ const DG_FILES = {
 };
 
 function DotGithubExplorer({ isMobile }) {
-  const [sel, setSel] = useState("CODEOWNERS");
+  const [sel, setSel] = usePageState("sel", "CODEOWNERS");
   const file = DG_FILES[sel];
   return (
     <div>
@@ -70,3 +70,6 @@ export default function DotGithubModule({ isMobile }) {
     </div>
   );
 }
+
+
+

--- a/src/components/modules/GitFlowModule.jsx
+++ b/src/components/modules/GitFlowModule.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { usePageState } from "../../hooks/usePageState";
 import T from "../../constants/tokens";
 import { InfoBox, SectionTitle, CommandCard } from "../shared";
 
@@ -46,8 +46,8 @@ const FLOW_STEPS = [
 ];
 
 function GitFlowSimulator({ isMobile }) {
-  const [stepIndex, setStepIndex] = useState(0);
-  const [log, setLog] = useState(["Simulator ready. Click Run Step to start Git Flow."]);
+  const [stepIndex, setStepIndex] = usePageState("stepIndex", 0);
+  const [log, setLog] = usePageState("log", ["Simulator ready. Click Run Step to start Git Flow."]);
 
   const done = stepIndex >= FLOW_STEPS.length;
   const currentStep = done ? null : FLOW_STEPS[stepIndex];
@@ -156,3 +156,6 @@ export default function GitFlowModule({ isMobile }) {
     </div>
   );
 }
+
+
+

--- a/src/components/modules/GithubApiModule.jsx
+++ b/src/components/modules/GithubApiModule.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { usePageState } from "../../hooks/usePageState";
 import T from "../../constants/tokens";
 import { InfoBox, SectionTitle } from "../shared";
 
@@ -11,7 +11,7 @@ const API_EX = [
 ];
 
 function APIExplorer({ isMobile }) {
-  const [sel, setSel] = useState(0);
+  const [sel, setSel] = usePageState("sel", 0);
   const ex = API_EX[sel];
   const isGet = ex.method === "GET";
   const methodStyle = { background: isGet ? T.greenBgMedium : T.blueBgLight, border: "1px solid " + (isGet ? T.greenBorderMedium : T.blueBorderLight), borderRadius: 4, fontSize: 10, fontWeight: 700, color: isGet ? T.green : T.blue, padding: "2px 7px", fontFamily: "monospace" };
@@ -85,3 +85,6 @@ export default function GithubApiModule({ isMobile }) {
     </div>
   );
 }
+
+
+

--- a/src/components/modules/IssuesModule.jsx
+++ b/src/components/modules/IssuesModule.jsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { usePageState } from "../../hooks/usePageState";
 import T from "../../constants/tokens";
 import { InfoBox, SectionTitle } from "../shared";
 
@@ -12,7 +13,7 @@ const ISSUE_LABELS = [
 ];
 
 function IssuesSimulator({ isMobile }) {
-  const [issues, setIssues] = useState([
+  const [issues, setIssues] = usePageState("issues", [
     { id: 1, title: "Login button crashes on Safari", label: "bug", state: "open", comments: 3, author: "alice", body: "Steps: open Safari, click login, app freezes." },
     { id: 2, title: "Add dark mode support", label: "enhancement", state: "open", comments: 7, author: "bob", body: "Users requested a dark theme." },
     { id: 3, title: "Fix typo in README", label: "good first issue", state: "closed", comments: 1, author: "charlie", body: "Line 42: recieve should be receive." },
@@ -20,7 +21,7 @@ function IssuesSimulator({ isMobile }) {
   const [form, setForm] = useState({ title: "", label: "bug", body: "" });
   const [selId, setSelId] = useState(null);
   const sel = issues.find((i) => i.id === selId) || null;
-  const [filter, setFilter] = useState("open");
+  const [filter, setFilter] = usePageState("filter", "open");
 
   const create = () => {
     if (!form.title.trim()) return;
@@ -122,3 +123,6 @@ export default function IssuesModule({ isMobile }) {
     </div>
   );
 }
+
+
+

--- a/src/components/modules/MergeModule.jsx
+++ b/src/components/modules/MergeModule.jsx
@@ -1,11 +1,11 @@
-import { useState } from "react";
+import { usePageState } from "../../hooks/usePageState";
 import T from "../../constants/tokens";
 import { InfoBox, SectionTitle, CommandCard } from "../shared";
 
 function MergeSimulator() {
-  const [mode, setMode] = useState("idle");
-  const [file, setFile] = useState("");
-  const [mergeLog, setMergeLog] = useState([]);
+  const [mode, setMode] = usePageState("mode", "idle");
+  const [file, setFile] = usePageState("file", "");
+  const [mergeLog, setMergeLog] = usePageState("mergeLog", []);
 
   const triggerMerge = () => {
     setMode("conflict");
@@ -137,3 +137,6 @@ export default function MergeModule() {
     </div>
   );
 }
+
+
+

--- a/src/components/modules/PagesModule.jsx
+++ b/src/components/modules/PagesModule.jsx
@@ -1,11 +1,12 @@
 import { useState } from "react";
+import { usePageState } from "../../hooks/usePageState";
 import T from "../../constants/tokens";
 import { InfoBox, SectionTitle } from "../shared";
 
 function PagesSimulator({ isMobile }) {
-  const [source, setSource] = useState("branch");
-  const [step, setStep] = useState(0);
-  const [deployed, setDeployed] = useState(false);
+  const [source, setSource] = usePageState("source", "branch");
+  const [step, setStep] = usePageState("step", 0);
+  const [deployed, setDeployed] = usePageState("deployed", false);
   const [building, setBuilding] = useState(false);
 
   const deploy = () => {
@@ -100,3 +101,6 @@ export default function PagesModule({ isMobile }) {
     </div>
   );
 }
+
+
+

--- a/src/components/modules/ProjectsModule.jsx
+++ b/src/components/modules/ProjectsModule.jsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { usePageState } from "../../hooks/usePageState";
 import T from "../../constants/tokens";
 import { InfoBox, SectionTitle } from "../shared";
 
@@ -11,7 +12,7 @@ const INIT_KANBAN = {
 const KCOLS = { todo: { label: "To Do", color: T.muted }, inprog: { label: "In Progress", color: T.amber }, review: { label: "In Review", color: T.blue }, done: { label: "Done", color: T.green } };
 
 function ProjectsSimulator({ isMobile }) {
-  const [cols, setCols] = useState(INIT_KANBAN);
+  const [cols, setCols] = usePageState("cols", INIT_KANBAN);
   const [drag, setDrag] = useState(null);
   const [over, setOver] = useState(null);
   const tcolor = (t) => ({ bug: T.red, enhancement: T.blue, docs: T.purple })[t] || T.muted;
@@ -87,3 +88,6 @@ export default function ProjectsModule({ isMobile }) {
     </div>
   );
 }
+
+
+

--- a/src/components/modules/ProtectionModule.jsx
+++ b/src/components/modules/ProtectionModule.jsx
@@ -1,9 +1,10 @@
 import { useState } from "react";
+import { usePageState } from "../../hooks/usePageState";
 import T from "../../constants/tokens";
 import { InfoBox, SectionTitle } from "../shared";
 
 function ProtectionSim({ isMobile }) {
-  const [rules, setRules] = useState({ pr: true, approvals: 1, ci: true, noForce: true, noDel: true, upToDate: false, signed: false });
+  const [rules, setRules] = usePageState("rules", { pr: true, approvals: 1, ci: true, noForce: true, noDel: true, upToDate: false, signed: false });
   const [scenarioId, setScenarioId] = useState(null);
   const toggle = (k) => setRules((r) => ({ ...r, [k]: !r[k] }));
 
@@ -94,3 +95,6 @@ export default function ProtectionModule({ isMobile }) {
     </div>
   );
 }
+
+
+

--- a/src/components/modules/PullRequestModule.jsx
+++ b/src/components/modules/PullRequestModule.jsx
@@ -1,9 +1,9 @@
-import { useState } from "react";
+import { usePageState } from "../../hooks/usePageState";
 import T from "../../constants/tokens";
 import { Badge, InfoBox, ConceptDiagram, SectionTitle, CommandCard } from "../shared";
 
 function PRSimulator() {
-  const [step, setStep] = useState(0);
+  const [step, setStep] = usePageState("step", 0);
   const steps = [
     { icon: "🌿", label: "Branch pushed", desc: "git push -u origin feature/user-auth" },
     { icon: "📝", label: "PR Opened", desc: "GitHub shows diff, you write description" },
@@ -90,3 +90,6 @@ Users need to sign in to access their saved data (Fixes #42)
     </div>
   );
 }
+
+
+

--- a/src/components/modules/QuizModule.jsx
+++ b/src/components/modules/QuizModule.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { usePageState } from "../../hooks/usePageState";
 import T from "../../constants/tokens";
 import { InfoBox } from "../shared";
 
@@ -16,11 +16,11 @@ const QUESTIONS = [
 ];
 
 function Quiz({ isMobile }) {
-  const [idx, setIdx] = useState(0);
-  const [sel, setSel] = useState(null);
-  const [score, setScore] = useState(0);
-  const [done, setDone] = useState(false);
-  const [showExp, setShowExp] = useState(false);
+  const [idx, setIdx] = usePageState("idx", 0);
+  const [sel, setSel] = usePageState("sel", null);
+  const [score, setScore] = usePageState("score", 0);
+  const [done, setDone] = usePageState("done", false);
+  const [showExp, setShowExp] = usePageState("showExp", false);
 
   const q = QUESTIONS[idx];
 
@@ -112,3 +112,6 @@ export default function QuizModule({ isMobile }) {
     </div>
   );
 }
+
+
+

--- a/src/components/modules/ReleasesModule.jsx
+++ b/src/components/modules/ReleasesModule.jsx
@@ -1,9 +1,10 @@
 import { useState } from "react";
+import { usePageState } from "../../hooks/usePageState";
 import T from "../../constants/tokens";
 import { InfoBox, SectionTitle } from "../shared";
 
 function ReleasesSimulator({ isMobile }) {
-  const [releases, setReleases] = useState([
+  const [releases, setReleases] = usePageState("releases", [
     { tag: "v2.1.0", name: "The Performance Update", date: "2026-03-01", pre: false, notes: "- 40% faster loads\n- Fixed 12 bugs\n- New dark mode" },
     { tag: "v2.0.0", name: "Major Rewrite", date: "2026-02-01", pre: false, notes: "- Complete redesign\n- New auth\n- Breaking: API v1 removed" },
     { tag: "v2.2.0-beta", name: "Beta: AI Features", date: "2026-03-08", pre: true, notes: "- Experimental AI\n- Not for production" },
@@ -97,3 +98,6 @@ export default function ReleasesModule({ isMobile }) {
     </div>
   );
 }
+
+
+

--- a/src/components/modules/StagingModule.jsx
+++ b/src/components/modules/StagingModule.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { usePageState } from "../../hooks/usePageState";
 import T from "../../constants/tokens";
 import { InfoBox, SectionTitle, CommandCard } from "../shared";
 
@@ -11,10 +11,10 @@ const MOCK_FILES = [
 ];
 
 function StagingSimulator({ isMobile }) {
-  const [files, setFiles] = useState(MOCK_FILES.map((f) => ({ ...f, staged: false })));
-  const [committed, setCommitted] = useState([]);
-  const [msg, setMsg] = useState("");
-  const [phase, setPhase] = useState("working");
+  const [files, setFiles] = usePageState("files", MOCK_FILES.map((f) => ({ ...f, staged: false })));
+  const [committed, setCommitted] = usePageState("committed", []);
+  const [msg, setMsg] = usePageState("msg", "");
+  const [phase, setPhase] = usePageState("phase", "working");
 
   const unstaged = files.filter((f) => !f.staged);
   const staged = files.filter((f) => f.staged);
@@ -197,3 +197,6 @@ export default function StagingModule({ isMobile }) {
     </div>
   );
 }
+
+
+

--- a/src/components/modules/VisualizerModule.jsx
+++ b/src/components/modules/VisualizerModule.jsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, useRef, useEffect } from "react";
+import { usePageState } from "../../hooks/usePageState";
 import T from "../../constants/tokens";
 import { InfoBox, SectionTitle, CommandCard } from "../shared";
 
@@ -189,11 +190,11 @@ function InteractiveSimulator() {
   const inputRef = useRef(null);
 
   const initialCommit = { id: randId(), msg: "initial commit", branch: "main", color: T.green };
-  const [commits, setCommits] = useState([initialCommit]);
-  const [edges, setEdges] = useState([]);
-  const [branches, setBranches] = useState({ main: { color: T.green, tip: initialCommit.id, base: null } });
-  const [head, setHead] = useState("main");
-  const [log, setLog] = useState([
+  const [commits, setCommits] = usePageState("commits", [initialCommit]);
+  const [edges, setEdges] = usePageState("edges", []);
+  const [branches, setBranches] = usePageState("branches", { main: { color: T.green, tip: initialCommit.id, base: null } });
+  const [head, setHead] = usePageState("head", "main");
+  const [log, setLog] = usePageState("log", [
     { type: "system", text: "Repository initialized with branch 'main' and initial commit." },
     { type: "hint", text: "Try: git branch feature/login  →  git checkout feature/login  →  git commit -m \"add login\"" },
   ]);
@@ -499,3 +500,6 @@ export default function VisualizerModule({ isMobile }) {
     </div>
   );
 }
+
+
+

--- a/src/hooks/usePageState.jsx
+++ b/src/hooks/usePageState.jsx
@@ -1,0 +1,93 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
+
+const STORAGE_PREFIX = "git-simulator:page-state:v1";
+const DEBOUNCE_MS = 300;
+const APP_STORAGE_KEYS = {
+  activePage: "git-simulator:active-page:v1",
+};
+
+const PageSessionContext = createContext({ pageId: "home" });
+
+const isBrowser = () => typeof window !== "undefined";
+
+const getPageStorageKey = (pageId) => `${STORAGE_PREFIX}:${pageId}`;
+
+const readPageState = (pageId) => {
+  if (!isBrowser()) return {};
+  try {
+    const raw = window.localStorage.getItem(getPageStorageKey(pageId));
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    return {};
+  }
+};
+
+const writePageState = (pageId, pageState) => {
+  if (!isBrowser()) return;
+  try {
+    window.localStorage.setItem(getPageStorageKey(pageId), JSON.stringify(pageState));
+  } catch {
+    // Ignore storage write failures (private mode/quota/security constraints).
+  }
+};
+
+export const clearPersistedPageState = (pageId) => {
+  if (!isBrowser()) return;
+  try {
+    window.localStorage.removeItem(getPageStorageKey(pageId));
+  } catch {
+    // Ignore storage removal failures.
+  }
+};
+
+export const getPersistedActivePage = () => {
+  if (!isBrowser()) return null;
+  try {
+    return window.localStorage.getItem(APP_STORAGE_KEYS.activePage);
+  } catch {
+    return null;
+  }
+};
+
+export const setPersistedActivePage = (pageId) => {
+  if (!isBrowser()) return;
+  try {
+    window.localStorage.setItem(APP_STORAGE_KEYS.activePage, pageId);
+  } catch {
+    // Ignore storage write failures.
+  }
+};
+
+export function PageSessionProvider({ pageId, children }) {
+  const value = useMemo(() => ({ pageId }), [pageId]);
+  return <PageSessionContext.Provider value={value}>{children}</PageSessionContext.Provider>;
+}
+
+export function usePageState(stateKey, initialValue) {
+  const { pageId } = useContext(PageSessionContext);
+
+  const [value, setValue] = useState(() => {
+    const pageState = readPageState(pageId);
+    if (Object.prototype.hasOwnProperty.call(pageState, stateKey)) {
+      return pageState[stateKey];
+    }
+    return typeof initialValue === "function" ? initialValue() : initialValue;
+  });
+
+  const timerRef = useRef(null);
+
+  useEffect(() => {
+    clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => {
+      const pageState = readPageState(pageId);
+      writePageState(pageId, { ...pageState, [stateKey]: value });
+    }, DEBOUNCE_MS);
+    return () => clearTimeout(timerRef.current);
+  }, [pageId, stateKey, value]);
+
+  const setValueStable = useCallback((v) => setValue(v), []);
+
+  return [value, setValueStable];
+}


### PR DESCRIPTION
Feature implemented: Per-page persistent session state with reset option.
Files added/modified:

src/hooks/usePageState.jsx: Custom hook for localStorage-backed per-page state with debounced writes.
src/App.jsx: Integrated PageSessionProvider, per-page reset logic, and persistent active page.
src/components/layout/Topbar.jsx: Added and restyled Reset Page button for better visibility.
Interactive modules (e.g., VisualizerModule.jsx, ProjectsModule.jsx, etc.): State persistence applied only to meaningful state; transient UI state reverted to useState.
Static modules: Restored to original state.